### PR TITLE
ReadMe Fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ int main()
 Just call the file makefile without an extension for now.
 
 ## 6: Add these arguments and variables to the make file
-NOTE: build recipes must be spaced using a tab character:
+IMPORTANT NOTE: build recipes (build_osx) must be spaced using a tab character, copy/pasting Markdown tends to convert tabs to spaces:
 
 ```
 COMPILER = clang++

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Add libraylib.a, raylib.h, and raymath.g from your built raylib source to the `l
 #include <raylib.h>
 #include <raymath.h>
 
-Int main()
+int main()
 {
 	InitWindow(400, 224, "Template-4.0.0");
 	


### PR DESCRIPTION
Fixes #1
Fixed the `int main` typo in step 4 of the readme. 

Closes #3
Updated Step 6 of the readme to make instructions more clear. Copy/pasting Markdown tabs tends to convert tabs to spaces and causes trouble with the build recipe.